### PR TITLE
Fixes #2 readable planet counts

### DIFF
--- a/app/styles/_app.scss
+++ b/app/styles/_app.scss
@@ -374,17 +374,21 @@
                 width: 183px;
                 height: 183px;
                 margin: 0 auto;
+                position: relative;
             }
             .planet-count{
                 width: 30px;
                 height: 30px;
-                color: black;
+                color: #B4E0E4;
                 text-align: center;
                 border-radius: 50%;
                 line-height: 30px;
                 background: #222;
                 text-shadow: 1px 1px 1px #333;
                 border: 2px solid #2c4f63;
+                position: absolute;
+                top: 120px;
+                left: 25px;
             }
 
             .white-star { background: url('../img/stars.png') no-repeat  -19px   -11px;  }


### PR DESCRIPTION
I changed the position and color of the planet count UI element. I placed it at the bottom left position relative to the image of the star so that it kind of looks like a planet on its orbit. I changed the planet count color and is now easier to read.
